### PR TITLE
Link libraries statically

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -6,6 +6,7 @@ set(BUILD_TESTING OFF)
 
 # Build only static externals
 set(BUILD_SHARED_LIBS OFF)
+set(BUILD_STATIC_LIBS ON)
 
 # Skip install rules for all externals
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL ON)

--- a/src/the_dude_to_human/CMakeLists.txt
+++ b/src/the_dude_to_human/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(the_dude_to_human
     TheDudeToHuman.cpp
 )
 
-target_link_libraries(the_dude_to_human PRIVATE common sqlite libssh2 zlib fmt::fmt)
+target_link_libraries(the_dude_to_human PRIVATE common sqlite libssh2::libssh2_static zlibstatic fmt::fmt)
 if (MSVC)
     target_link_libraries(the_dude_to_human PRIVATE getopt wsock32 ws2_32)
 endif()


### PR DESCRIPTION
Builds both libssh2 and zlib statically to generate a single executable for releases. 

Solves issue in #3