### PR TITLE
database: Only print credentials if required

### DIFF
--- a/src/the_dude_to_human/TheDudeToHuman.cpp
+++ b/src/the_dude_to_human/TheDudeToHuman.cpp
@@ -30,6 +30,7 @@ static void PrintHelp(const char* argv0) {
         << " [options] <filename>\n"
            "-f, --file                                 Load the specified database file\n"
            "-o, --out                                  Store database location\n"
+           "-c, --credentials                          Save credentials in plain text\n"
            "-m, --mikrotik=user:password@address:port  Connect to the specified mikrotik device\n"
            //"-d, --database=user:password@address:port  Connect to the specified database\n"
            "-h, --help                                 Display this help and exit\n"
@@ -54,6 +55,7 @@ int main(int argc, char** argv) {
     std::string filepath{};
 
     bool has_out_filepath{};
+    bool has_credentials{};
     std::string out_filepath{};
 
     bool has_mikrotik{};
@@ -72,6 +74,7 @@ int main(int argc, char** argv) {
         // clang-format off
         {"file", required_argument, 0, 'f'},
         {"out", required_argument, 0, 'o'},
+        {"credentials", no_argument, 0, 'c'},
         {"mikrotik", required_argument, 0, 'm'},
         //{"database", optional_argument, 0, 'd'},
         {"help", no_argument, 0, 'h'},
@@ -81,7 +84,7 @@ int main(int argc, char** argv) {
     };
 
     while (optind < argc) {
-        int arg = getopt_long(argc, argv, "f:o:m:hv", long_options, &option_index);
+        int arg = getopt_long(argc, argv, "f:o:cm:hv", long_options, &option_index);
         if (arg != -1) {
             switch (static_cast<char>(arg)) {
             case 'f': {
@@ -96,6 +99,9 @@ int main(int argc, char** argv) {
                 out_filepath = str_arg;
                 break;
             }
+            case 'c':
+                has_credentials = true;
+                break;
             case 'h':
                 PrintHelp(argv[0]);
                 return 0;
@@ -203,7 +209,7 @@ int main(int argc, char** argv) {
 
         if (has_out_filepath) {
             std::cout << "Saving database " << out_filepath << "\n";
-            db.SaveDatabase(out_filepath);
+            db.SaveDatabase(out_filepath, has_credentials);
         }
     }
 }

--- a/src/the_dude_to_human/database/dude_database.cpp
+++ b/src/the_dude_to_human/database/dude_database.cpp
@@ -47,8 +47,8 @@ int DudeDatabase::GetOutages(Sqlite::SqlData& data) const {
     return db.GetTableData(data, "outages");
 }
 
-int DudeDatabase::SaveDatabase(const std::string& db_file) {
-    return SerializeDatabaseJson(this, db_file);
+int DudeDatabase::SaveDatabase(const std::string& db_file, bool has_credentials) {
+    return SerializeDatabaseJson(this, db_file, has_credentials);
 }
 
 std::vector<DataFormat> DudeDatabase::ListUsedDataFormats() const {

--- a/src/the_dude_to_human/database/dude_database.h
+++ b/src/the_dude_to_human/database/dude_database.h
@@ -27,7 +27,7 @@ public:
     int GetObjs(Sqlite::SqlData& data) const;
     int GetOutages(Sqlite::SqlData& data) const;
 
-    int SaveDatabase(const std::string& db_file);
+    int SaveDatabase(const std::string& db_file, bool has_credentials);
 
     // Usefull to find new unsuported types
     std::vector<DataFormat> ListUsedDataFormats() const;

--- a/src/the_dude_to_human/database/dude_json.cpp
+++ b/src/the_dude_to_human/database/dude_json.cpp
@@ -10,11 +10,11 @@
 namespace Database {
 
 template <typename T>
-static std::string SerializeData(std::vector<T> obj) {
+static std::string SerializeData(std::vector<T> obj, bool has_credentials) {
     std::string json = "";
 
     for (const DudeObj& data : obj) {
-        json += fmt::format("{{{}}},", data.SerializeJson());
+        json += fmt::format("{{{}}},", data.SerializeJson(has_credentials));
     }
     if (!obj.empty()) {
         json.pop_back();
@@ -23,36 +23,42 @@ static std::string SerializeData(std::vector<T> obj) {
     return json;
 }
 
-int SerializeDatabaseJson(DudeDatabase* db, const std::string& db_file) {
+template <typename T>
+static std::string SerializeTable(std::string table_name, std::vector<T> obj,
+                                  bool has_credentials) {
+    return fmt::format("{}\": [{}],\n", table_name, SerializeData(obj, has_credentials));
+}
+
+int SerializeDatabaseJson(DudeDatabase* db, const std::string& db_file, bool has_credentials) {
     std::ofstream jsonFile(db_file);
     if (!jsonFile.is_open())
         return 1;
 
     jsonFile << "{\n";
-    jsonFile << fmt::format("\"serverConfig\": [{}],\n", SerializeData(db->GetServerConfigData()));
-    jsonFile << fmt::format("\"tool\": [{}],\n", SerializeData(db->GetToolData()));
-    jsonFile << fmt::format("\"file\": [{}],\n", SerializeData(db->GetFileData()));
-    jsonFile << fmt::format("\"notes\": [{}],\n", SerializeData(db->GetNotesData()));
-    jsonFile << fmt::format("\"Map\": [{}],\n", SerializeData(db->GetMapData()));
-    // jsonFile << fmt::format("\"Probe\": [{}],\n", SerializeData(db->GetProbeData()));
-    jsonFile << fmt::format("\"deviceType\": [{}],\n", SerializeData(db->GetDeviceTypeData()));
-    jsonFile << fmt::format("\"Device\": [{}],\n", SerializeData(db->GetDeviceData()));
-    jsonFile << fmt::format("\"Network\": [{}],\n", SerializeData(db->GetNetworkData()));
-    jsonFile << fmt::format("\"Service\": [{}],\n", SerializeData(db->GetServiceData()));
-    jsonFile << fmt::format("\"Notification\": [{}],\n", SerializeData(db->GetNotificationData()));
-    jsonFile << fmt::format("\"Link\": [{}],\n", SerializeData(db->GetLinkData()));
-    jsonFile << fmt::format("\"LinkType\": [{}],\n", SerializeData(db->GetLinkTypeData()));
-    jsonFile << fmt::format("\"DataSource\": [{}],\n", SerializeData(db->GetDataSourceData()));
-    jsonFile << fmt::format("\"ObjectList\": [{}],\n", SerializeData(db->GetObjectListData()));
-    jsonFile << fmt::format("\"DeviceGroup\": [{}],\n", SerializeData(db->GetDeviceGroupData()));
-    jsonFile << fmt::format("\"Function\": [{}],\n", SerializeData(db->GetFunctionData()));
-    jsonFile << fmt::format("\"SnmpProfile\": [{}],\n", SerializeData(db->GetSnmpProfileData()));
-    jsonFile << fmt::format("\"Panel\": [{}],\n", SerializeData(db->GetPanelData()));
-    jsonFile << fmt::format("\"SysLogRule\": [{}],\n", SerializeData(db->GetSysLogRuleData()));
-    jsonFile << fmt::format("\"NetworkMapElement\": [{}],\n",
-                            SerializeData(db->GetNetworkMapElementData()));
-    jsonFile << fmt::format("\"ChartLine\": [{}],\n", SerializeData(db->GetChartLineData()));
-    jsonFile << fmt::format("\"PanelElement\": [{}]\n", SerializeData(db->GetPanelElementData()));
+    jsonFile << SerializeTable("serverConfig", db->GetServerConfigData(), has_credentials);
+    jsonFile << SerializeTable("tool", db->GetToolData(), has_credentials);
+    jsonFile << SerializeTable("file", db->GetFileData(), has_credentials);
+    jsonFile << SerializeTable("notes", db->GetNotesData(), has_credentials);
+    jsonFile << SerializeTable("Map", db->GetMapData(), has_credentials);
+    // jsonFile << SerializeTable("Probe", db->GetProbeData(), has_credentials);
+    jsonFile << SerializeTable("deviceType", db->GetDeviceTypeData(), has_credentials);
+    jsonFile << SerializeTable("Device", db->GetDeviceData(), has_credentials);
+    jsonFile << SerializeTable("Network", db->GetNetworkData(), has_credentials);
+    jsonFile << SerializeTable("Service", db->GetServiceData(), has_credentials);
+    jsonFile << SerializeTable("Notification", db->GetNotificationData(), has_credentials);
+    jsonFile << SerializeTable("Link", db->GetLinkData(), has_credentials);
+    jsonFile << SerializeTable("LinkType", db->GetLinkTypeData(), has_credentials);
+    jsonFile << SerializeTable("DataSource", db->GetDataSourceData(), has_credentials);
+    jsonFile << SerializeTable("ObjectList", db->GetObjectListData(), has_credentials);
+    jsonFile << SerializeTable("DeviceGroup", db->GetDeviceGroupData(), has_credentials);
+    jsonFile << SerializeTable("Function", db->GetFunctionData(), has_credentials);
+    jsonFile << SerializeTable("SnmpProfile", db->GetSnmpProfileData(), has_credentials);
+    jsonFile << SerializeTable("Panel", db->GetPanelData(), has_credentials);
+    jsonFile << SerializeTable("SysLogRule", db->GetSysLogRuleData(), has_credentials);
+    jsonFile << SerializeTable("NetworkMapElement", db->GetNetworkMapElementData(),
+                               has_credentials);
+    jsonFile << SerializeTable("ChartLine", db->GetChartLineData(), has_credentials);
+    jsonFile << SerializeTable("PanelElement", db->GetPanelElementData(), has_credentials);
     jsonFile << "}";
 
     jsonFile.close();

--- a/src/the_dude_to_human/database/dude_json.h
+++ b/src/the_dude_to_human/database/dude_json.h
@@ -4,6 +4,6 @@
 #pragma once
 
 namespace Database {
-    class DudeDatabase;
-    int SerializeDatabaseJson(DudeDatabase* db, const std::string& db_file);
+class DudeDatabase;
+int SerializeDatabaseJson(DudeDatabase* db, const std::string& db_file, bool has_credentials);
 } // namespace Database

--- a/src/the_dude_to_human/database/dude_types.h
+++ b/src/the_dude_to_human/database/dude_types.h
@@ -234,7 +234,7 @@ struct StringArrayField {
 
 struct DudeObj {
     virtual ~DudeObj() {}
-    virtual std::string SerializeJson() const {
+    virtual std::string SerializeJson(bool has_credentials) const {
         return "\"object_id\":-1";
     }
 };
@@ -347,7 +347,7 @@ struct ServerConfigData : DudeObj {
     LongArrayField unique_id;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"timeZoneHistory\":{}, \"discoverSkipTypes\":{}, \"discoverSkipProbes\":{}, "
             "\"customColors\":{}, \"chartLineColors\":{}, \"notifyIds\":{}, "
@@ -449,7 +449,7 @@ struct ToolData : DudeObj {
     TextField command;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"builtin\":{}, \"type\":{}, \"deviceId\":{}, \"objectId\":{}, "
                            "\"command\":{}, \"name\":{}",
                            builtin.SerializeJson(), type.SerializeJson(), device_id.SerializeJson(),
@@ -465,7 +465,7 @@ struct FileData : DudeObj {
     TextField file_name;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"parentId\":{}, \"objectId\":{}, \"fileName\":{}, \"name\":{}",
                            parent_id.SerializeJson(), object_id.SerializeJson(),
                            file_name.SerializeJson(), name.SerializeJson());
@@ -479,7 +479,7 @@ struct NotesData : DudeObj {
     TimeField time_added;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"objectId\":{}, \"parentId\":{}, \"timeAdded\":{}, \"name\":{}",
                            object_id.SerializeJson(), parent_id.SerializeJson(),
                            time_added.SerializeJson(), name.SerializeJson());
@@ -574,7 +574,7 @@ struct MapData : DudeObj {
     TextField list_type;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"notifyIds\":{}, \"useStaticColor\":{}, \"useLinkColor\":{}, "
             "\"useLinkLabelColor\":{}, \"useLinkFullColor\":{}, \"useDeviceLabel\":{}, "
@@ -684,7 +684,7 @@ struct ProbeData : DudeObj {
     TextField tcp_send_1;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"logicProbeIds\":{}, \"snmpValueOid\":{}, \"snmpOid\":{}, \"dnsAddresses\":{}, "
             "\"snmpAvailIfUp\":{}, \"tcpOnlyConnect\":{}, \"tcpFirstReceive\":{}, "
@@ -728,7 +728,7 @@ struct DeviceTypeData : DudeObj {
     TextField url;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"ignoredServices\":{}, \"allowedServices\":{}, "
                            "\"requiredServices\":{}, \"imageId\":{}, \"imageScale\":{}, "
                            "\"objectId\":{}, \"nextId\":{}, \"url\":{}, \"name\":{}",
@@ -768,7 +768,7 @@ struct DeviceData : DudeObj {
     MacAddressField mac;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"parentIds\":{}, \"notifyIds\":{}, \"dnsNames\":{}, \"ip\":{}, \"secureMode\":{}, "
             "\"routerOs\":{}, \"dudeServer\":{}, \"notifyUse\":{}, \"proveEnabled\":{}, "
@@ -784,8 +784,9 @@ struct DeviceData : DudeObj {
             object_id.SerializeJson(), prove_interval.SerializeJson(),
             prove_timeout.SerializeJson(), prove_down_count.SerializeJson(),
             custom_field_3.SerializeJson(), custom_field_2.SerializeJson(),
-            custom_field_1.SerializeJson(), password.SerializeJson(), username.SerializeJson(),
-            mac.SerializeJson(), name.SerializeJson());
+            custom_field_1.SerializeJson(), has_credentials ? password.SerializeJson() : "*****",
+            has_credentials ? username.SerializeJson() : "*****", mac.SerializeJson(),
+            name.SerializeJson());
     }
 };
 
@@ -797,7 +798,7 @@ struct NetworkData : DudeObj {
     IntField net_map_element;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"subnets\":{}, \"objectId\":{}, \"netMapId\":{}, \"netMapElement\":{}, \"name\":{}",
             subnets.SerializeJson(), object_id.SerializeJson(), net_map_id.SerializeJson(),
@@ -831,7 +832,7 @@ struct ServiceData : DudeObj {
     LongField value;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"notifyIds\":{}, \"enabled\":{}, \"history\":{}, \"notifyUse\":{}, \"acked\":{}, "
             "\"probePort\":{}, \"probeInterval\":{}, \"probeTimeout\":{}, \"probeDownCount\":{}, "
@@ -885,7 +886,7 @@ struct NotificationData : DudeObj {
     TextField text_template;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"statusList\":{}, \"groupNotifyIds\":{}, \"mailCc\":{}, \"activity\":{}, "
             "\"logUseColor\":{}, \"enabled\":{}, \"mailTlsMode\":{}, \"sysLogServer\":{}, "
@@ -904,9 +905,9 @@ struct NotificationData : DudeObj {
             repeat_count.SerializeJson(), object_id.SerializeJson(), rype_id.SerializeJson(),
             mail_server.SerializeJson(), mail_port.SerializeJson(), log_prefix.SerializeJson(),
             mail_subject.SerializeJson(), mail_to.SerializeJson(), mail_from.SerializeJson(),
-            mail_password.SerializeJson(), mail_user.SerializeJson(),
-            mail_server_dns.SerializeJson(), mail_server6.SerializeJson(),
-            text_template.SerializeJson(), name.SerializeJson());
+            has_credentials ? mail_password.SerializeJson() : "*****",
+            has_credentials ? mail_user.SerializeJson() : "*****", mail_server_dns.SerializeJson(),
+            mail_server6.SerializeJson(), text_template.SerializeJson(), name.SerializeJson());
     }
 };
 
@@ -925,7 +926,7 @@ struct LinkData : DudeObj {
     LongField speed;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"history\":{}, \"masteringType\":{}, \"masterDevice\":{}, \"masterInterface\":{}, "
             "\"netMapId\":{}, \"netMapElementId\":{}, \"typeId\":{}, \"txDataSourceId\":{}, "
@@ -948,7 +949,7 @@ struct LinkTypeData : DudeObj {
     LongField snmp_speed;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"objectId\":{}, \"style\":{}, \"thickness\":{}, \"snmpType\":{}, "
                            "\"nextId\":{}, \"snmpSpeed\":{}, \"name\":{}",
                            object_id.SerializeJson(), style.SerializeJson(),
@@ -973,7 +974,7 @@ struct DataSourceData : DudeObj {
     TextField unit;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"enabled\":{}, \"functionDeviceId\":{}, \"functionInterval\":{}, "
                            "\"dataSourceType\":{}, \"objectId\":{}, \"keepTimeRaw\":{}, "
                            "\"keepTime10min\":{}, \"keepTime2hour\":{}, \"keepTime1Day\":{}, "
@@ -994,7 +995,7 @@ struct ObjectListData : DudeObj {
     TextField type;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"ordered\":{}, \"objectId\":{}, \"type\":{}, \"name\":{}",
                            ordered.SerializeJson(), object_id.SerializeJson(), type.SerializeJson(),
                            name.SerializeJson());
@@ -1007,7 +1008,7 @@ struct DeviceGroupData : DudeObj {
     IntField object_id;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"deviceIds\":{}, \"objectId\":{}, \"name\":{}",
                            device_ids.SerializeJson(), object_id.SerializeJson(),
                            name.SerializeJson());
@@ -1025,7 +1026,7 @@ struct FunctionData : DudeObj {
     TextField code;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"argumentDescriptors\":{}, \"builtin\":{}, \"minArguments\":{}, \"maxArguments\":{}, "
             "\"objectId\":{}, \"description\":{}, \"code\":{}, \"name\":{}",
@@ -1050,7 +1051,7 @@ struct SnmpProfileData : DudeObj {
     TextField community;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"version\":{}, \"port\":{}, \"security\":{}, \"authMethod\":{}, \"crypthMethod\":{}, "
             "\"tryCount\":{}, \"tryTimeout\":{}, \"objectId\":{}, \"cryptPassword\":{}, "
@@ -1073,7 +1074,7 @@ struct PanelData : DudeObj {
     TextField type;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"ordered\":{}, \"locked\":{}, \"titleBars\":{}, \"objectId\":{}, "
                            "\"topElementId\":{}, \"admin\":{}, \"type\":{}, \"name\":{}",
                            ordered.SerializeJson(), locked.SerializeJson(),
@@ -1099,7 +1100,7 @@ struct SysLogRuleData : DudeObj {
     TextField regexp;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"regexpNot\":{}, \"sourceSet\":{}, \"regexpSet\":{}, \"enabled\":{}, "
             "\"sourceNot\":{}, \"sourceFirst\":{}, \"sourceSecond\":{}, \"action\":{}, "
@@ -1148,7 +1149,7 @@ struct NetworkMapElementData : DudeObj {
     LongArrayField item_font;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"itemUseAckedColor\":{}, \"itemUseLabel\":{}, \"itemUseShapes\":{}, "
             "\"itemUseFont\":{}, \"itemUseImage\":{}, "
@@ -1189,7 +1190,7 @@ struct ChartLineData : DudeObj {
     IntField next_id;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format("\"chartId\":{}, \"sourceId\":{}, \"lineStyle\":{}, \"lineColor\":{}, "
                            "\"lineOpacity\":{}, \"fillColor\":{}, \"fillOpacity\":{}, "
                            "\"objectId\":{}, \"nextId\":{}, \"name\":{}",
@@ -1214,7 +1215,7 @@ struct PanelElementData : DudeObj {
     LongArrayField obj_meta;
     TextField name;
 
-    std::string SerializeJson() const override {
+    std::string SerializeJson(bool has_credentials) const override {
         return fmt::format(
             "\"split\":{}, \"panelId\":{}, \"splitType\":{}, \"splitShare\":{}, \"firstId\":{}, "
             "\"secondId\":{}, \"objId\":{}, \"objectId\":{}, \"objMeta\":{}, \"name\":{}",


### PR DESCRIPTION
I really don't feel comfortable keeping a json with my credentials exposed, specially since I only need device properties. For this reason I decided to hide them by default unless explicitly requested.