### PR TITLE
database: Escape characters

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -7,6 +7,7 @@
 #include <codecvt>
 #include <locale>
 #include <sstream>
+#include <vector>
 
 #include "common/string_util.h"
 
@@ -141,14 +142,71 @@ std::string ReplaceAll(std::string result, const std::string& src, const std::st
     return result;
 }
 
-std::string Sanitize(std::string str) {
-    str = ReplaceAll(str, std::string("\\"), std::string("\\\\"));
-    str = ReplaceAll(str, std::string("\""), std::string("\\\""));
-    str = ReplaceAll(str, std::string("\b"), std::string("\\b"));
-    str = ReplaceAll(str, std::string("\f"), std::string("\\f"));
-    str = ReplaceAll(str, std::string("\n"), std::string("\\n"));
-    str = ReplaceAll(str, std::string("\r"), std::string("\\r"));
-    str = ReplaceAll(str, std::string("\t"), std::string("\\t"));
+std::string ReplaceChar(std::string src, char c, const std::string& dest, std::size_t length) {
+    std::size_t instances = 0;
+    for (std::size_t i = 0; i < length; i++) {
+        if (src.at(i) == c)
+            instances++;
+    }
+
+    if (instances == 0) {
+        return src;
+    }
+
+    std::vector<char> text;
+    text.reserve(length + (instances * dest.size()));
+    for (std::size_t i = 0; i < length; i++) {
+        if (src.at(i) == c) {
+            for (std::size_t e = 0; e < dest.size(); e++) {
+                text.push_back(dest.at(e));
+            }
+            continue;
+        }
+        text.push_back(src.at(i));
+    }
+    return std::string(text.begin(), text.end());
+}
+
+std::string Sanitize(std::string str, std::size_t length) {
+    if (str.size() != length) {
+        return "Invalid size";
+    }
+
+    str = ReplaceChar(str, '\\', "\\\\", length);
+    str = ReplaceChar(str, '\0', "\\\\0", length);
+    str = ReplaceAll(str, "\x1", "\\\\x01");
+    str = ReplaceAll(str, "\x2", "\\\\x02");
+    str = ReplaceAll(str, "\x3", "\\\\x03");
+    str = ReplaceAll(str, "\x4", "\\\\x04");
+    str = ReplaceAll(str, "\x5", "\\\\x05");
+    str = ReplaceAll(str, "\x6", "\\\\x06");
+    str = ReplaceAll(str, "\x7", "\\\\x07");
+    str = ReplaceAll(str, "\b", "\\b");
+    str = ReplaceAll(str, "\t", "\\t");
+    str = ReplaceAll(str, "\n", "\\n");
+    str = ReplaceAll(str, "\v", "\\\\v");
+    str = ReplaceAll(str, "\f", "\\f");
+    str = ReplaceAll(str, "\r", "\\r");
+    str = ReplaceAll(str, "\xe", "\\\\x0e");
+    str = ReplaceAll(str, "\xf", "\\\\x0f");
+    str = ReplaceAll(str, "\x10", "\\\\x10");
+    str = ReplaceAll(str, "\x11", "\\\\x11");
+    str = ReplaceAll(str, "\x12", "\\\\x12");
+    str = ReplaceAll(str, "\x13", "\\\\x13");
+    str = ReplaceAll(str, "\x14", "\\\\x14");
+    str = ReplaceAll(str, "\x15", "\\\\x15");
+    str = ReplaceAll(str, "\x16", "\\\\x16");
+    str = ReplaceAll(str, "\x17", "\\\\x17");
+    str = ReplaceAll(str, "\x18", "\\\\x18");
+    str = ReplaceAll(str, "\x19", "\\\\x19");
+    str = ReplaceAll(str, "\x1a", "\\\\x1a");
+    str = ReplaceAll(str, "\x1b", "\\\\x1b");
+    str = ReplaceAll(str, "\x1c", "\\\\x1c");
+    str = ReplaceAll(str, "\x1d", "\\\\x1d");
+    str = ReplaceAll(str, "\x1e", "\\\\x1e");
+    str = ReplaceAll(str, "\x1f", "\\\\x1f");
+    str = ReplaceAll(str, "\xa8", "\\\\xa8");
+    str = ReplaceAll(str, "\"", "\\\"");
     return str;
 }
 

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -37,7 +37,10 @@ bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _
 
 [[nodiscard]] std::string ReplaceAll(std::string result, const std::string& src,
                                      const std::string& dest);
-[[nodiscard]] std::string Sanitize(std::string str);
+// Binary replace ignoring null terminators
+[[nodiscard]] std::string ReplaceChar(std::string src, char c, const std::string& dest,
+                                      std::size_t length);
+[[nodiscard]] std::string Sanitize(std::string str, std::size_t length);
 
 [[nodiscard]] std::string UTF16ToUTF8(std::u16string_view input);
 [[nodiscard]] std::u16string UTF8ToUTF16(std::string_view input);

--- a/src/the_dude_to_human/database/dude_field_parser.cpp
+++ b/src/the_dude_to_human/database/dude_field_parser.cpp
@@ -411,14 +411,14 @@ ParserResult DudeFieldParser::ReadField(StringArrayField& field, FieldId id) {
 
     field.entries.resize(field.entry_count);
     for (std::size_t i = 0; i < field.entry_count; ++i) {
-        result = ReadData(&field.entries[i].data_size, sizeof(StringArrayField::entry_count));
+        result = ReadData(&field.entries[i].text_size, sizeof(StringArrayField::entry_count));
         if (result != ParserResult::Success) {
             RestoreOffset();
             return result;
         }
 
-        std::vector<char> raw_text(field.entries[i].data_size);
-        result = ReadData(raw_text.data(), field.entries[i].data_size);
+        std::vector<char> raw_text(field.entries[i].text_size);
+        result = ReadData(raw_text.data(), field.entries[i].text_size);
         if (result != ParserResult::Success) {
             RestoreOffset();
             return result;

--- a/src/the_dude_to_human/database/dude_json.cpp
+++ b/src/the_dude_to_human/database/dude_json.cpp
@@ -24,9 +24,10 @@ static std::string SerializeData(std::vector<T> obj, bool has_credentials) {
 }
 
 template <typename T>
-static std::string SerializeTable(std::string table_name, std::vector<T> obj,
-                                  bool has_credentials) {
-    return fmt::format("{}\": [{}],\n", table_name, SerializeData(obj, has_credentials));
+static std::string SerializeTable(std::string table_name, std::vector<T> obj, bool has_credentials,
+                                  bool has_coma = true) {
+    return fmt::format("\"{}\": [{}]{}\n", table_name, SerializeData(obj, has_credentials),
+                       has_coma ? "," : "");
 }
 
 int SerializeDatabaseJson(DudeDatabase* db, const std::string& db_file, bool has_credentials) {
@@ -40,7 +41,7 @@ int SerializeDatabaseJson(DudeDatabase* db, const std::string& db_file, bool has
     jsonFile << SerializeTable("file", db->GetFileData(), has_credentials);
     jsonFile << SerializeTable("notes", db->GetNotesData(), has_credentials);
     jsonFile << SerializeTable("Map", db->GetMapData(), has_credentials);
-    // jsonFile << SerializeTable("Probe", db->GetProbeData(), has_credentials);
+    jsonFile << SerializeTable("Probe", db->GetProbeData(), has_credentials);
     jsonFile << SerializeTable("deviceType", db->GetDeviceTypeData(), has_credentials);
     jsonFile << SerializeTable("Device", db->GetDeviceData(), has_credentials);
     jsonFile << SerializeTable("Network", db->GetNetworkData(), has_credentials);
@@ -58,7 +59,7 @@ int SerializeDatabaseJson(DudeDatabase* db, const std::string& db_file, bool has
     jsonFile << SerializeTable("NetworkMapElement", db->GetNetworkMapElementData(),
                                has_credentials);
     jsonFile << SerializeTable("ChartLine", db->GetChartLineData(), has_credentials);
-    jsonFile << SerializeTable("PanelElement", db->GetPanelElementData(), has_credentials);
+    jsonFile << SerializeTable("PanelElement", db->GetPanelElementData(), has_credentials, false);
     jsonFile << "}";
 
     jsonFile.close();

--- a/src/the_dude_to_human/database/dude_types.h
+++ b/src/the_dude_to_human/database/dude_types.h
@@ -142,7 +142,7 @@ struct TextField {
     std::string text{};
 
     std::string SerializeJson() const {
-        return fmt::format("\"{}\"", Common::Sanitize(text));
+        return fmt::format("\"{}\"", Common::Sanitize(text, text_size));
     }
 };
 
@@ -208,7 +208,7 @@ struct MacAddressField {
 };
 
 struct StringArrayEntry {
-    u16 data_size{};
+    u16 text_size{};
     std::string text{};
 };
 
@@ -222,7 +222,7 @@ struct StringArrayField {
         std::string array = "";
 
         for (const StringArrayEntry& entry : entries) {
-            array += fmt::format("\"{}\",", Common::Sanitize(entry.text));
+            array += fmt::format("\"{}\",", Common::Sanitize(entry.text, entry.text_size));
         }
         if (!entries.empty()) {
             array.pop_back();
@@ -784,8 +784,9 @@ struct DeviceData : DudeObj {
             object_id.SerializeJson(), prove_interval.SerializeJson(),
             prove_timeout.SerializeJson(), prove_down_count.SerializeJson(),
             custom_field_3.SerializeJson(), custom_field_2.SerializeJson(),
-            custom_field_1.SerializeJson(), has_credentials ? password.SerializeJson() : "*****",
-            has_credentials ? username.SerializeJson() : "*****", mac.SerializeJson(),
+            custom_field_1.SerializeJson(),
+            has_credentials ? password.SerializeJson() : "\"*****\"",
+            has_credentials ? username.SerializeJson() : "\"*****\"", mac.SerializeJson(),
             name.SerializeJson());
     }
 };
@@ -905,9 +906,10 @@ struct NotificationData : DudeObj {
             repeat_count.SerializeJson(), object_id.SerializeJson(), rype_id.SerializeJson(),
             mail_server.SerializeJson(), mail_port.SerializeJson(), log_prefix.SerializeJson(),
             mail_subject.SerializeJson(), mail_to.SerializeJson(), mail_from.SerializeJson(),
-            has_credentials ? mail_password.SerializeJson() : "*****",
-            has_credentials ? mail_user.SerializeJson() : "*****", mail_server_dns.SerializeJson(),
-            mail_server6.SerializeJson(), text_template.SerializeJson(), name.SerializeJson());
+            has_credentials ? mail_password.SerializeJson() : "\"*****\"",
+            has_credentials ? mail_user.SerializeJson() : "\"*****\"",
+            mail_server_dns.SerializeJson(), mail_server6.SerializeJson(),
+            text_template.SerializeJson(), name.SerializeJson());
     }
 };
 


### PR DESCRIPTION
Probes table use a lot of non printable characters. This causes many issues with the json string validation even if the character is escaped. For this reason many are replaced with double backslash  to prevent the parser from invalidating the json.

Null terminators are handled differently because common string utilities end early when encountering this character.