### PR TITLE
database: Format json with multiple lines, use signed ids, format IP address

### DIFF
--- a/src/the_dude_to_human/database/dude_database.cpp
+++ b/src/the_dude_to_human/database/dude_database.cpp
@@ -109,7 +109,7 @@ std::vector<T> DudeDatabase::GetObjectData(DataFormat format,
 
         const T obj_data = (this->*RawToObjData)(parser);
 
-        if (id != obj_data.object_id.value) {
+        if (id != (u32)obj_data.object_id.value) {
             printf("Corrupted Entry %d\n", id);
             continue;
         }
@@ -622,7 +622,7 @@ NotificationData DudeDatabase::GetNotificationData(DudeFieldParser& parser) cons
     parser.ReadField(data.repeat_interval, FieldId::Notification_RepeatInterval);
     parser.ReadField(data.repeat_count, FieldId::Notification_RepeatCount);
     parser.ReadField(data.object_id, FieldId::SysId);
-    parser.ReadField(data.rype_id, FieldId::Notification_RypeID);
+    parser.ReadField(data.type_id, FieldId::Notification_TypeID);
     parser.ReadField(data.mail_server, FieldId::Notification_MailServer);
     parser.ReadField(data.mail_port, FieldId::Notification_MailPort);
     parser.ReadField(data.log_prefix, FieldId::Notification_LogPrefix);

--- a/src/the_dude_to_human/database/dude_field_id.h
+++ b/src/the_dude_to_human/database/dude_field_id.h
@@ -284,7 +284,7 @@ enum class FieldId : u32 {
 
     // Notification
     Notification_Enabled = 0x103e80,
-    Notification_RypeID = 0x103e81,
+    Notification_TypeID = 0x103e81,
     Notification_Activity = 0x103e82,
     Notification_TextTemplate = 0x103e83,
     Notification_MailServer = 0x103e84,

--- a/src/the_dude_to_human/database/dude_json.cpp
+++ b/src/the_dude_to_human/database/dude_json.cpp
@@ -14,7 +14,7 @@ static std::string SerializeData(std::vector<T> obj, bool has_credentials) {
     std::string json = "";
 
     for (const DudeObj& data : obj) {
-        json += fmt::format("{{{}}},", data.SerializeJson(has_credentials));
+        json += fmt::format("\n    {{{}}},", data.SerializeJson(has_credentials));
     }
     if (!obj.empty()) {
         json.pop_back();
@@ -26,7 +26,7 @@ static std::string SerializeData(std::vector<T> obj, bool has_credentials) {
 template <typename T>
 static std::string SerializeTable(std::string table_name, std::vector<T> obj, bool has_credentials,
                                   bool has_coma = true) {
-    return fmt::format("\"{}\": [{}]{}\n", table_name, SerializeData(obj, has_credentials),
+    return fmt::format("\"{}\": [{}\n]{}\n", table_name, SerializeData(obj, has_credentials),
                        has_coma ? "," : "");
 }
 

--- a/src/the_dude_to_human/database/dude_types.h
+++ b/src/the_dude_to_human/database/dude_types.h
@@ -98,7 +98,7 @@ struct ByteField {
 // This is FieldType::Int
 struct IntField {
     FieldInfo info{};
-    u32 value{};
+    s32 value{};
 
     std::string SerializeJson() const {
         return fmt::format("{}", value);
@@ -157,6 +157,23 @@ struct IntArrayField {
 
         for (u32 entry : data) {
             array += fmt::format("{},", entry);
+        }
+        if (!data.empty()) {
+            array.pop_back();
+        }
+
+        return fmt::format("[{}]", array);
+    }
+};
+
+struct IpArrayField : IntArrayField {
+    std::string SerializeJson() const {
+        std::string array = "";
+
+        for (u32 entry : data) {
+            IpAddress ip{};
+            memcpy(&ip, &entry, sizeof(u32));
+            array += fmt::format("{}.{}.{}.{},", ip[0], ip[1], ip[2], ip[3]);
         }
         if (!data.empty()) {
             array.pop_back();
@@ -647,7 +664,7 @@ struct ProbeData : DudeObj {
     IntArrayField logic_probe_ids;
     IntArrayField snmp_value_oid;
     IntArrayField snmp_oid;
-    IntArrayField dns_addresses;
+    IpArrayField dns_addresses;
     BoolField snmp_avail_if_up;
     BoolField tcp_only_connect;
     BoolField tcp_first_receive;
@@ -740,7 +757,7 @@ struct DeviceData : DudeObj {
     IntArrayField parent_ids;
     IntArrayField notify_ids;
     StringArrayField dns_names;
-    IntArrayField ip;
+    IpArrayField ip;
     BoolField secure_mode;
     BoolField router_os;
     BoolField dude_server;
@@ -868,7 +885,7 @@ struct NotificationData : DudeObj {
     ByteField repeat_interval;
     ByteField repeat_count;
     IntField object_id;
-    IntField rype_id;
+    IntField type_id;
     IntField mail_server;
     IntField mail_port;
     TextField log_prefix;
@@ -888,7 +905,7 @@ struct NotificationData : DudeObj {
             "\"mailCc\":{}, \"activity\":{}, \"logUseColor\":{}, \"enabled\":{}, "
             "\"mailTlsMode\":{}, \"sysLogServer\":{}, \"sysLogPort\":{}, \"soundFileId\":{}, "
             "\"logColor\":{}, \"speakRate\":{}, \"speakVolume\":{}, \"delayInterval\":{}, "
-            "\"repeatInterval\":{}, \"repeatCount\":{}, \"rypeId\":{}, \"mailServer\":{}, "
+            "\"repeatInterval\":{}, \"repeatCount\":{}, \"typeId\":{}, \"mailServer\":{}, "
             "\"mailPort\":{}, \"logPrefix\":{}, \"mailSubject\":{}, \"mailTo\":{}, "
             "\"mailFrom\":{}, \"mailPassword\":{}, \"mailUser\":{}, \"mailServerDns\":{}, "
             "\"mailServer6\":{}, \"textTemplate\":{}",
@@ -898,7 +915,7 @@ struct NotificationData : DudeObj {
             sys_log_server.SerializeJson(), sys_log_port.SerializeJson(),
             sound_file_id.SerializeJson(), log_color.SerializeJson(), speak_rate.SerializeJson(),
             speak_volume.SerializeJson(), delay_interval.SerializeJson(),
-            repeat_interval.SerializeJson(), repeat_count.SerializeJson(), rype_id.SerializeJson(),
+            repeat_interval.SerializeJson(), repeat_count.SerializeJson(), type_id.SerializeJson(),
             mail_server.SerializeJson(), mail_port.SerializeJson(), log_prefix.SerializeJson(),
             mail_subject.SerializeJson(), mail_to.SerializeJson(), mail_from.SerializeJson(),
             has_credentials ? mail_password.SerializeJson() : "\"*****\"",


### PR DESCRIPTION
This PR fixes multiple issues in the JSON format.

- Typo in `Notification_TypeID`
- IP address are now displayed in human readable form
- ID's now display negative values since -1 is `undefined`
- Each object now has a single line instead of each table

closes: #14 , #13 