### PR TITLE
Quote device's IP to get a valid JSON literal

### DIFF
--- a/src/the_dude_to_human/database/dude_types.h
+++ b/src/the_dude_to_human/database/dude_types.h
@@ -173,7 +173,7 @@ struct IpArrayField : IntArrayField {
         for (u32 entry : data) {
             IpAddress ip{};
             memcpy(&ip, &entry, sizeof(u32));
-            array += fmt::format("{}.{}.{}.{},", ip[0], ip[1], ip[2], ip[3]);
+            array += fmt::format("\"{}.{}.{}.{}\",", ip[0], ip[1], ip[2], ip[3]);
         }
         if (!data.empty()) {
             array.pop_back();


### PR DESCRIPTION
Adding quotes around IP address to get a valid JSON output.