### PR TITLE
mikrotik: Implement sftp operations

### DIFF
--- a/src/the_dude_to_human/TheDudeToHuman.cpp
+++ b/src/the_dude_to_human/TheDudeToHuman.cpp
@@ -33,7 +33,7 @@ static void PrintHelp(const char* argv0) {
            "-f, --file                                 Load the specified database file\n"
            "-o, --out                                  Save json database file\n"
            "-c, --credentials                          Save credentials in plain text\n"
-           "-m, --mikrotik=user:password@address:port  Connect to the specified mikrotik device\n"
+           "-m, --mikrotik user:password@address:port  Connect to the specified mikrotik device\n"
            //"-d, --database=user:password@address:port  Connect to the specified database\n"
            "-h, --help                                 Display this help and exit\n"
            "-v, --version                              Print tool version\n";
@@ -241,10 +241,12 @@ int main(int argc, char** argv) {
             std::cout << "Unable to connect to device\n";
             return 0;
         }
-        std::string output{};
-        std::cout << "Executing command 'system health print;'\n";
-        device.Execute("system health print;", &output);
-        std::cout << output;
+        has_filepath = true;
+        filepath = "DudeToHuman.db";
+        if (!device.DownloadDatabase(filepath)) {
+            std::cout << "Unable to download database\n";
+            return 0;
+        }
         device.Disconnect();
     }
 

--- a/src/the_dude_to_human/mikrotik/mikrotik_device.cpp
+++ b/src/the_dude_to_human/mikrotik/mikrotik_device.cpp
@@ -10,10 +10,15 @@
 #include <unistd.h>
 #endif
 
+#include <fstream>
+#include <iostream>
+
 #include "libssh2.h"
+#include "libssh2_sftp.h"
 #include "the_dude_to_human/mikrotik/mikrotik_device.h"
 
 #define BUFSIZE 32000
+#define DOWNLOADBUFSIZE 8192
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4996)
@@ -106,10 +111,35 @@ bool MikrotikDevice::Execute(std::string commandline, std::string* output) {
     return true;
 }
 
-void MikrotikDevice::DownloadDatabase() {
+bool MikrotikDevice::DownloadDatabase(std::string filename) {
     if (!is_connected) {
-        return;
+        return false;
     }
+
+    fprintf(stdout, "Exporting database.\n");
+
+    std::string output{};
+    if (!Execute("dude export-db backup-file=\"" + filename + "\";", &output))
+        return false;
+
+    output.clear();
+    if (!Execute("file print count-only where name =\"" + filename + "\";", &output))
+        return false;
+
+    if (!output.starts_with("1\r")) {
+        fprintf(stderr, "Failed to export the database. File not found\n");
+        return false;
+    }
+
+    InitializeSFTP();
+    DownloadFile(filename);
+    DisconnectSFTP();
+
+    output.clear();
+    if (!Execute("file remove \"" + filename + "\";", &output))
+        return false;
+
+    return true;
 }
 
 void MikrotikDevice::UploadDatabase() {
@@ -131,6 +161,17 @@ int MikrotikDevice::InitializeSSH() {
     if (!session) {
         fprintf(stderr, "Could not initialize SSH session.\n");
         return 2;
+    }
+
+    return 0;
+}
+
+int MikrotikDevice::InitializeSFTP() {
+    sftp_session = libssh2_sftp_init(session);
+
+    if (!sftp_session) {
+        fprintf(stderr, "sftp initialization failed\n");
+        return 1;
     }
 
     return 0;
@@ -244,6 +285,51 @@ int MikrotikDevice::ExecuteSSH(std::string commandline, std::string* output) {
     return result;
 }
 
+int MikrotikDevice::DownloadFile(std::string filename) {
+    sftp_handle = libssh2_sftp_open(sftp_session, filename.c_str(), LIBSSH2_FXF_READ, 0);
+    if (!sftp_handle) {
+        fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                libssh2_sftp_last_error(sftp_session));
+        return 1;
+    }
+
+    std::ofstream output_file(filename, std::ios::binary);
+    if (!output_file) {
+        fprintf(stderr, "Unable to create output file\n");
+        return 1;
+    }
+
+    LIBSSH2_SFTP_ATTRIBUTES attrs;
+    libssh2_sftp_fstat_ex(sftp_handle, &attrs, 0);
+
+    fprintf(stdout, "Downloading file %llu bytes...\n", attrs.filesize);
+
+    u64 i = 0;
+    u64 total_read_size = 0;
+    do {
+        char buffer[DOWNLOADBUFSIZE];
+        ssize_t nread;
+
+        /* loop until we fail */
+        nread = libssh2_sftp_read(sftp_handle, buffer, DOWNLOADBUFSIZE);
+
+        if (nread <= 0) {
+            break;
+        }
+
+        total_read_size += nread;
+
+        if ((++i % 10) == 0) {
+            fprintf(stdout, "\t%llu%%\n", total_read_size * 100 / attrs.filesize);
+        }
+
+        output_file.write(buffer, nread);
+    } while (1);
+    output_file.close();
+    fprintf(stdout, "Download complete!\n");
+    return 0;
+}
+
 int MikrotikDevice::DisconnectSSH() {
     int result = 0;
     auto lock = std::scoped_lock(session_mutex);
@@ -262,6 +348,16 @@ int MikrotikDevice::DisconnectSSH() {
 #endif
 
     return result;
+}
+
+int MikrotikDevice::DisconnectSFTP() {
+    if (sftp_handle)
+        libssh2_sftp_close(sftp_handle);
+
+    if (sftp_session)
+        libssh2_sftp_shutdown(sftp_session);
+
+    return 0;
 }
 
 } // namespace Mikrotik

--- a/src/the_dude_to_human/mikrotik/mikrotik_device.h
+++ b/src/the_dude_to_human/mikrotik/mikrotik_device.h
@@ -12,6 +12,12 @@
 struct _LIBSSH2_SESSION;
 typedef struct _LIBSSH2_SESSION LIBSSH2_SESSION;
 
+struct _LIBSSH2_SFTP;
+typedef struct _LIBSSH2_SFTP LIBSSH2_SFTP;
+
+struct _LIBSSH2_SFTP_HANDLE;
+typedef struct _LIBSSH2_SFTP_HANDLE LIBSSH2_SFTP_HANDLE;
+
 namespace Mikrotik {
 
 // Connects to a mikrotik device using ssh
@@ -25,16 +31,19 @@ public:
 
     bool Execute(std::string commandline, std::string* output = nullptr);
 
-    void DownloadDatabase();
+    bool DownloadDatabase(std::string filename);
     void UploadDatabase();
 
 private:
     int InitializeSSH();
+    int InitializeSFTP();
     int ConnectSSH(std::string username, std::string password);
 
     int ExecuteSSH(std::string commandline, std::string* output = nullptr);
+    int DownloadFile(std::string filename);
 
     int DisconnectSSH();
+    int DisconnectSFTP();
 
     bool is_connected{};
 
@@ -46,6 +55,8 @@ private:
 
     s32 sock{};
     LIBSSH2_SESSION* session = nullptr;
+    LIBSSH2_SFTP* sftp_session = nullptr;
+    LIBSSH2_SFTP_HANDLE* sftp_handle = nullptr;
     std::mutex session_mutex;
 };
 


### PR DESCRIPTION
I had this one pending for a while, the program supported connecting via ssh to any mikrotik device it didn't did anything useful with that connection. 

This PR implements the sftp transactions. We can now successfully export and download the database into a file from any dude server.

```
Conecting to 192.168.xx.xx:22
Exporting database.
Downloading file 20453 bytes...
Download complete!
Reading database DudeToHuman.db
Opened database successfully
Map 10158: Main
Device 30319: 192.168.xx.xx
Device 30325: 192.168.xx.xx
Saving database C:\TheDudeToHuman\initial.json
```