### PR TITLE
database: IntArrayFields use signed values

### DIFF
--- a/src/the_dude_to_human/database/dude_types.h
+++ b/src/the_dude_to_human/database/dude_types.h
@@ -150,12 +150,12 @@ struct TextField {
 struct IntArrayField {
     FieldInfo info{};
     u16 entries{};
-    std::vector<u32> data{};
+    std::vector<s32> data{};
 
     std::string SerializeJson() const {
         std::string array = "";
 
-        for (u32 entry : data) {
+        for (s32 entry : data) {
             array += fmt::format("{},", entry);
         }
         if (!data.empty()) {


### PR DESCRIPTION
`logicProbeIds":[4294967295]` and `"activity":[4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]` are signed values and should be displayed as `-1`